### PR TITLE
chore: add conventional commit validation

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+
+# Provide commit message template for new commits (not merge/amend)
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+
+# Only add template for regular commits (not merge, squash, amend, etc.)
+if [ -z "$COMMIT_SOURCE" ]; then
+  # Check if the commit message file is empty or only has comments
+  if ! grep -qv '^#' "$COMMIT_MSG_FILE" 2>/dev/null; then
+    cat > "$COMMIT_MSG_FILE" <<EOF
+# <type>[optional scope]: <description>
+#
+# [optional body]
+#
+# [optional footer(s)]
+#
+# Types:
+#   feat:     New feature (minor version bump)
+#   fix:      Bug fix (patch version bump)
+#   docs:     Documentation only changes
+#   style:    Code style (formatting, semicolons, etc.)
+#   refactor: Code refactoring (no feature/fix)
+#   perf:     Performance improvements
+#   test:     Adding or updating tests
+#   build:    Build system or dependencies
+#   ci:       CI/CD configuration
+#   chore:    Other maintenance tasks
+#   revert:   Revert previous commit
+#
+# Breaking Changes:
+#   feat!: breaking change description
+#   Or add "BREAKING CHANGE:" in footer
+#
+# Examples:
+#   feat: add user authentication
+#   fix(api): handle null response in user endpoint
+#   docs: update README with installation steps
+#   perf: optimize database queries for practice tree
+#
+# Remember:
+#   - Use lowercase for type and scope
+#   - Keep subject under 100 characters
+#   - Don't end subject with period
+#   - Use imperative mood ("add" not "adds" or "added")
+EOF
+  fi
+fi

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,39 +1,74 @@
 /**
  * Commitlint Configuration
  *
- * Enforces Conventional Commits specification
- * https://www.conventionalcommits.org/
+ * Enforces Conventional Commits format:
+ * <type>[optional scope]: <description>
  *
- * Valid commit types:
- * - feat: A new feature
- * - fix: A bug fix
- * - docs: Documentation only changes
- * - style: Changes that don't affect code meaning (white-space, formatting, etc)
- * - refactor: Code change that neither fixes a bug nor adds a feature
- * - perf: Code change that improves performance
- * - test: Adding missing tests or correcting existing tests
- * - build: Changes that affect the build system or external dependencies
- * - ci: Changes to CI configuration files and scripts
- * - chore: Other changes that don't modify src or test files
- * - revert: Reverts a previous commit
+ * Valid types:
+ * - feat: New feature (minor version bump)
+ * - fix: Bug fix (patch version bump)
+ * - docs: Documentation changes
+ * - style: Code style changes (formatting, no logic change)
+ * - refactor: Code refactoring
+ * - perf: Performance improvements
+ * - test: Adding or updating tests
+ * - build: Build system changes
+ * - ci: CI/CD changes
+ * - chore: Other changes (dependencies, config, etc.)
+ * - revert: Revert a previous commit
  *
- * Format: <type>(<scope>): <subject>
- * Example: feat(api): add endpoint for practice dependencies
+ * Breaking changes:
+ * - Add "!" after type: feat!: breaking change
+ * - Or add "BREAKING CHANGE:" in footer
  */
-
 export default {
 	extends: ['@commitlint/config-conventional'],
+
 	rules: {
+		// Enforce lowercase type
+		'type-case': [2, 'always', 'lower-case'],
+
+		// Enforce type is required
+		'type-empty': [2, 'never'],
+
+		// Allowed types
 		'type-enum': [
 			2,
 			'always',
-			['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'build', 'ci', 'chore', 'revert']
+			[
+				'feat', // New feature
+				'fix', // Bug fix
+				'docs', // Documentation
+				'style', // Formatting
+				'refactor', // Code restructuring
+				'perf', // Performance
+				'test', // Tests
+				'build', // Build system
+				'ci', // CI/CD
+				'chore', // Maintenance
+				'revert' // Revert commit
+			]
 		],
-		'subject-case': [2, 'never', ['upper-case', 'pascal-case']],
+
+		// Subject must not be empty
 		'subject-empty': [2, 'never'],
+
+		// Subject must be lowercase
+		'subject-case': [2, 'never', ['sentence-case', 'start-case', 'pascal-case', 'upper-case']],
+
+		// Subject must not end with period
 		'subject-full-stop': [2, 'never', '.'],
-		'type-case': [2, 'always', 'lower-case'],
-		'type-empty': [2, 'never'],
+
+		// Header (type + subject) max length
+		'header-max-length': [2, 'always', 100],
+
+		// Body should have blank line before it
+		'body-leading-blank': [1, 'always'],
+
+		// Footer should have blank line before it
+		'footer-leading-blank': [1, 'always'],
+
+		// Scope must be lowercase
 		'scope-case': [2, 'always', 'lower-case']
 	}
 }

--- a/docs/COMMIT-CONVENTIONS.md
+++ b/docs/COMMIT-CONVENTIONS.md
@@ -1,0 +1,208 @@
+# Commit Message Conventions
+
+This project uses **[Conventional Commits](https://www.conventionalcommits.org/)** format to ensure consistent, semantic commit messages that work with automated release tools like release-please.
+
+## Quick Reference
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## Commit Types
+
+| Type       | Description             | Version Bump  |
+| ---------- | ----------------------- | ------------- |
+| `feat`     | New feature             | Minor (0.x.0) |
+| `fix`      | Bug fix                 | Patch (0.0.x) |
+| `perf`     | Performance improvement | Patch (0.0.x) |
+| `docs`     | Documentation only      | None          |
+| `style`    | Code style/formatting   | None          |
+| `refactor` | Code restructuring      | None          |
+| `test`     | Adding/updating tests   | None          |
+| `build`    | Build system changes    | None          |
+| `ci`       | CI/CD changes           | None          |
+| `chore`    | Maintenance tasks       | None          |
+| `revert`   | Revert previous commit  | None          |
+
+## Examples
+
+### Simple Commits
+
+```bash
+feat: add user authentication
+fix: resolve navigation bug in tree view
+docs: update README with installation steps
+perf: optimize database queries
+```
+
+### With Scope
+
+```bash
+feat(auth): add OAuth2 support
+fix(api): handle null response in user endpoint
+docs(readme): add troubleshooting section
+perf(query): cache practice tree results
+```
+
+### With Body
+
+```bash
+feat: migrate to file-based architecture
+
+Replace PostgreSQL database with JSON file storage for improved
+performance and simplified deployment. This reduces initial page
+load time by 50% and eliminates database hosting costs.
+```
+
+### Breaking Changes
+
+**Method 1:** Add `!` after type
+
+```bash
+feat!: redesign API endpoints
+
+BREAKING CHANGE: All API endpoints now require authentication.
+Update your API calls to include authentication headers.
+```
+
+**Method 2:** Add footer
+
+```bash
+feat: redesign API endpoints
+
+BREAKING CHANGE: All API endpoints now require authentication.
+Update your API calls to include authentication headers.
+```
+
+## Git Hooks
+
+This project uses [Husky](https://typicode.github.io/husky/) to enforce commit message format:
+
+### 1. `prepare-commit-msg` Hook
+
+Provides a helpful template when creating commits:
+
+```bash
+git commit
+# Opens editor with template showing commit format and examples
+```
+
+### 2. `commit-msg` Hook
+
+Validates commit messages before they're saved:
+
+```bash
+git commit -m "Invalid message"
+# ✖ subject may not be empty [subject-empty]
+# ✖ type may not be empty [type-empty]
+```
+
+### 3. `pre-commit` Hook
+
+Runs linting and tests before commits:
+
+```bash
+git commit
+# → lint-staged (runs ESLint and Prettier on staged files)
+# → npm test (runs all tests)
+```
+
+## Rules
+
+### Required
+
+- ✅ Type must be one of the allowed types
+- ✅ Subject must not be empty
+- ✅ Type and scope must be lowercase
+- ✅ Subject must not end with a period
+
+### Recommended
+
+- ✅ Use imperative mood ("add" not "adds" or "added")
+- ✅ Keep header under 100 characters
+- ✅ Add blank line before body
+- ✅ Add blank line before footer
+
+## Testing Your Commit Message
+
+Before committing, you can test if your message is valid:
+
+```bash
+# Test a message
+echo "feat: add new feature" | npx commitlint
+
+# Get help with commit format
+npm run commit
+```
+
+## Common Mistakes
+
+### ❌ Missing Type
+
+```bash
+# Bad
+git commit -m "add new feature"
+
+# Good
+git commit -m "feat: add new feature"
+```
+
+### ❌ Uppercase Type
+
+```bash
+# Bad
+git commit -m "FEAT: add new feature"
+
+# Good
+git commit -m "feat: add new feature"
+```
+
+### ❌ Period at End
+
+```bash
+# Bad
+git commit -m "feat: add new feature."
+
+# Good
+git commit -m "feat: add new feature"
+```
+
+### ❌ Past Tense
+
+```bash
+# Bad
+git commit -m "feat: added new feature"
+
+# Good
+git commit -m "feat: add new feature"
+```
+
+## Why Conventional Commits?
+
+1. **Automated versioning** - release-please can determine version bumps
+2. **Automated changelogs** - Generate changelogs from commit history
+3. **Better navigation** - Search commits by type (all features, all fixes, etc.)
+4. **Clear communication** - Everyone understands commit purpose at a glance
+5. **Professional standard** - Industry-standard format
+
+## Configuration Files
+
+- `commitlint.config.js` - Commitlint rules and configuration
+- `.husky/commit-msg` - Hook that validates commit messages
+- `.husky/prepare-commit-msg` - Hook that provides commit template
+- `.husky/pre-commit` - Hook that runs linting and tests
+
+## Resources
+
+- [Conventional Commits Specification](https://www.conventionalcommits.org/)
+- [Commitlint Documentation](https://commitlint.js.org/)
+- [Angular Commit Guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format)
+- [Semantic Versioning](https://semver.org/)
+
+## Need Help?
+
+Run `npm run commit` to see the commit format help, or check `.husky/prepare-commit-msg` for the template that appears when you run `git commit`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,6 @@
 		"": {
 			"name": "interactive-cd",
 			"version": "0.5.1",
-			"dependencies": {
-				"@netlify/neon": "^0.1.0",
-				"pg": "^8.16.3"
-			},
 			"devDependencies": {
 				"@commitlint/cli": "^20.1.0",
 				"@commitlint/config-conventional": "^20.0.0",
@@ -1301,24 +1297,6 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
-		"node_modules/@neondatabase/serverless": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.10.4.tgz",
-			"integrity": "sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/pg": "8.11.6"
-			}
-		},
-		"node_modules/@netlify/neon": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@netlify/neon/-/neon-0.1.0.tgz",
-			"integrity": "sha512-7FlZRfpR61iePnwjamH8t8WnF7ZG87a3wnMojvBjfUYlSMGeHxawoFfI7eyqGEeUV7djuiTB8QkxB+XiPw83WA==",
-			"license": "ISC",
-			"dependencies": {
-				"@neondatabase/serverless": "0.x"
-			}
-		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2277,20 +2255,10 @@
 			"version": "24.8.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.1.tgz",
 			"integrity": "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.14.0"
-			}
-		},
-		"node_modules/@types/pg": {
-			"version": "8.11.6",
-			"resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
-			"integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"pg-protocol": "*",
-				"pg-types": "^4.0.1"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -5259,12 +5227,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/obuf": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-			"integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-			"license": "MIT"
-		},
 		"node_modules/onetime": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -5411,161 +5373,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14.16"
-			}
-		},
-		"node_modules/pg": {
-			"version": "8.16.3",
-			"resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
-			"integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
-			"license": "MIT",
-			"dependencies": {
-				"pg-connection-string": "^2.9.1",
-				"pg-pool": "^3.10.1",
-				"pg-protocol": "^1.10.3",
-				"pg-types": "2.2.0",
-				"pgpass": "1.0.5"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"optionalDependencies": {
-				"pg-cloudflare": "^1.2.7"
-			},
-			"peerDependencies": {
-				"pg-native": ">=3.0.1"
-			},
-			"peerDependenciesMeta": {
-				"pg-native": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/pg-cloudflare": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
-			"integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
-			"license": "MIT",
-			"optional": true
-		},
-		"node_modules/pg-connection-string": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
-			"integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
-			"license": "MIT"
-		},
-		"node_modules/pg-int8": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
-			"integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/pg-numeric": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
-			"integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/pg-pool": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
-			"integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"pg": ">=8.0"
-			}
-		},
-		"node_modules/pg-protocol": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-			"integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
-			"license": "MIT"
-		},
-		"node_modules/pg-types": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.1.0.tgz",
-			"integrity": "sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==",
-			"license": "MIT",
-			"dependencies": {
-				"pg-int8": "1.0.1",
-				"pg-numeric": "1.0.2",
-				"postgres-array": "~3.0.1",
-				"postgres-bytea": "~3.0.0",
-				"postgres-date": "~2.1.0",
-				"postgres-interval": "^3.0.0",
-				"postgres-range": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/pg/node_modules/pg-types": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
-			"integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-			"license": "MIT",
-			"dependencies": {
-				"pg-int8": "1.0.1",
-				"postgres-array": "~2.0.0",
-				"postgres-bytea": "~1.0.0",
-				"postgres-date": "~1.0.4",
-				"postgres-interval": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/pg/node_modules/postgres-array": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-			"integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/pg/node_modules/postgres-bytea": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-			"integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/pg/node_modules/postgres-date": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
-			"integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/pg/node_modules/postgres-interval": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
-			"integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-			"license": "MIT",
-			"dependencies": {
-				"xtend": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/pgpass": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
-			"integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
-			"license": "MIT",
-			"dependencies": {
-				"split2": "^4.1.0"
 			}
 		},
 		"node_modules/picocolors": {
@@ -5769,51 +5576,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/postgres-array": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
-			"integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/postgres-bytea": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
-			"integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
-			"license": "MIT",
-			"dependencies": {
-				"obuf": "~1.1.2"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/postgres-date": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
-			"integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/postgres-interval": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
-			"integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/postgres-range": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
-			"integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
-			"license": "MIT"
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -6212,6 +5974,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
 			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">= 10.x"
@@ -6686,6 +6449,7 @@
 			"version": "7.14.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
 			"integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unicorn-magic": {
@@ -7172,15 +6936,6 @@
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.4"
-			}
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build",
+		"commit": "npx @commitlint/cli --help-url https://github.com/conventional-changelog/commitlint/#what-is-commitlint",
+		"commit:validate": "npx commitlint --edit",
 		"dev": "vite dev",
 		"format:fix": "prettier --write '**/*.{js,yml,yaml,json,css,scss,toml,md,svelte}'",
 		"lint": "eslint .",


### PR DESCRIPTION
Add commitlint configuration with husky hooks to enforce
  conventional commit message format. This ensures all commits
  follow the proper format for release-please automation.

  Changes:
  - Add commitlint.config.js with validation rules
  - Add prepare-commit-msg hook with helpful template
  - Add commit message validation documentation
  - Add npm scripts for commit format help